### PR TITLE
Collection patterns

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='sparqlquery',
-    version='0.2.1',
+    version='0.2.2',
     keywords='rdf rdflib sparql orm',
     license='MIT',
     classifiers=[

--- a/sparqlquery/sparql/compiler.py
+++ b/sparqlquery/sparql/compiler.py
@@ -29,7 +29,7 @@ from sparqlquery.sparql import operators
 from sparqlquery.sparql.operators import FunctionCall
 from sparqlquery.sparql.patterns import GroupGraphPattern, UnionGraphPattern
 from sparqlquery.sparql.patterns import GraphPattern, TriplesSameSubject
-from sparqlquery.sparql.patterns import GraphGraphPattern, Triple
+from sparqlquery.sparql.patterns import GraphGraphPattern, Triple, CollectionPattern
 #from sparqlquery.sparql.query import *
 #from sparqlquery.sparql.queryforms import *
 from sparqlquery.sparql.helpers import RDF, XSD, is_a
@@ -103,8 +103,8 @@ class ExpressionCompiler(SPARQLCompiler):
                 return join(self.function(expression), '')
             elif isinstance(expression, Expression):
                 return join(self.unary(expression), '')
-            elif isinstance(expression, tuple):
-                return join(self.tuple_expression(expression))
+            elif isinstance(expression, CollectionPattern):
+                return join(self.collection_pattern(expression))
             else:
                 return self.term(expression)
         else:
@@ -160,7 +160,7 @@ class ExpressionCompiler(SPARQLCompiler):
         yield self.compile(expression, False)
         yield ')'
 
-    def tuple_expression(self, expression):
+    def collection_pattern(self, expression):
         yield "("
         for exp in expression:
             yield self.compile(exp)

--- a/sparqlquery/sparql/compiler.py
+++ b/sparqlquery/sparql/compiler.py
@@ -103,6 +103,8 @@ class ExpressionCompiler(SPARQLCompiler):
                 return join(self.function(expression), '')
             elif isinstance(expression, Expression):
                 return join(self.unary(expression), '')
+            elif isinstance(expression, tuple):
+                return join(self.tuple_expression(expression))
             else:
                 return self.term(expression)
         else:
@@ -157,6 +159,12 @@ class ExpressionCompiler(SPARQLCompiler):
         yield '('
         yield self.compile(expression, False)
         yield ')'
+
+    def tuple_expression(self, expression):
+        yield "("
+        for exp in expression:
+            yield self.compile(exp)
+        yield ")"
 
     def conditional(self, expression):
         operator = self.operator(expression.operator)

--- a/sparqlquery/sparql/patterns.py
+++ b/sparqlquery/sparql/patterns.py
@@ -2,8 +2,22 @@ import warnings
 from sparqlquery.sparql.expressions import and_
 
 __all__ = ['Triple', 'TriplesSameSubject', 'Filter', 'GraphPattern',
-           'GroupGraphPattern', 'UnionGraphPattern', 'union',
-           'optional', 'graph']
+           'GroupGraphPattern', 'UnionGraphPattern', 'CollectionPattern',
+           'union', 'optional', 'graph']
+
+
+class CollectionPattern(tuple):
+    def __str__(self):
+        return "CollectionPattern(%s)" % ", ".join(list(self))
+
+    @classmethod
+    def from_obj(cls, obj):
+        objs = []
+        for o in obj:
+            if isinstance(o, tuple):
+                o = cls.from_obj(o)
+            objs.append(o)
+        return cls(tuple(objs))
 
 
 class Triple(object):
@@ -22,8 +36,15 @@ class Triple(object):
     def from_obj(cls, obj):
         if isinstance(obj, Triple):
             return obj
-        else:
-            return cls(*obj)
+
+        s = obj[0]
+        p = obj[1]
+        o = obj[2]
+        if isinstance(s, tuple):
+            s = CollectionPattern.from_obj(s)
+        if isinstance(o, tuple):
+            o = CollectionPattern.from_obj(o)
+        return cls(s, p, o)
 
 
 class TriplesBlock(object):

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -418,16 +418,30 @@ class TestCompilingSelect(CompilingSelectBase):
             """
         )
 
-    def test_compiling_lists(self):
+    def test_compiling_collections(self):
         select = Select([v.x]).where(
-            (v.x, FOAF.name, (FOAF.knows, v.name))
+            ((v.x, v.y), FOAF.name, (FOAF.knows, v.name))
         )
         output = self.compiler.compile(select)
         assert tokens_equal(
             output, self.PREFIXES,
             """
             SELECT ?x WHERE {
-                ?x foaf:name ( foaf:knows ?name )
+                ( ?x ?y ) foaf:name ( foaf:knows ?name )
+            }
+            """
+        )
+
+    def test_nested_collections(self):
+        select = Select([v.x]).where(
+            (v.x, FOAF.name, ("Alice", (v.y, v.z)))
+        )
+        output = self.compiler.compile(select)
+        assert tokens_equal(
+            output, self.PREFIXES,
+            """
+            SELECT ?x WHERE {
+              ?x foaf:name ( "Alice" ( ?y ?z ) )
             }
             """
         )

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -417,3 +417,17 @@ class TestCompilingSelect(CompilingSelectBase):
             }
             """
         )
+
+    def test_compiling_lists(self):
+        select = Select([v.x]).where(
+            (v.x, FOAF.name, (FOAF.knows, v.name))
+        )
+        output = self.compiler.compile(select)
+        assert tokens_equal(
+            output, self.PREFIXES,
+            """
+            SELECT ?x WHERE {
+                ?x foaf:name ( foaf:knows ?name )
+            }
+            """
+        )

--- a/tests/test_patterns.py
+++ b/tests/test_patterns.py
@@ -25,6 +25,23 @@ class TestCreatingTriple:
         assert triple.object == "Alice"
         assert_raises(TypeError, Triple.from_obj, 1)
 
+    def test_from_obj_with_collection_pattern(self):
+        args = (Variable('x'), FOAF.name, ("Alice", Variable('restaurant')))
+        triple = Triple.from_obj(args)
+        assert triple.subject == Variable('x')
+        assert triple.predicate == FOAF.name
+        assert triple.object == ("Alice", Variable('restaurant'))
+        assert isinstance(triple.object, CollectionPattern)
+
+    def test_nested_collection_patterns(self):
+        args = (Variable('x'), FOAF.name, ("Alice", (Variable('y'), Variable('z'))))
+        triple = Triple.from_obj(args)
+        assert isinstance(triple.object, CollectionPattern)
+        assert triple.object[0] == "Alice"
+        assert isinstance(triple.object[1], CollectionPattern)
+        assert triple.object[1][0] == Variable('y')
+        assert triple.object[1][1] == Variable('z')
+
 class TestIteratingTriple:
     def setup(self):
         self.triple = Triple(Variable('x'), FOAF.name, "Alice")


### PR DESCRIPTION
I added some support for collections, so you should be able to create queries of the form:

    SELECT ?x WHERE {
      (?x ?y) FOAF.name ("x" "y" "z") .
    }

To create the above query with `sparqlquery`:

    q = Select([v.x]).where(
        ( (v.x, v.y), FOAF.name, ("x", "y", "z") )
    )

