### PR TITLE
Fix [true]div-related functionality and tests

### DIFF
--- a/sparqlquery/sparql/compiler.py
+++ b/sparqlquery/sparql/compiler.py
@@ -80,7 +80,7 @@ class ExpressionCompiler(SPARQLCompiler):
         operators.and_: 1, 'logical-and': 1,
         operators.eq: 2, 'RDFTerm-equal': 2, operators.ne: 2,
         operators.lt: 2, operators.gt: 2, operators.le: 2, operators.ge: 2,
-        operators.add: 3, operators.sub: 3, operators.mul: 4, operators.truediv: 4,
+        operators.add: 3, operators.sub: 3, operators.mul: 4, operators.div: 4, operators.truediv: 4,
         operators.pos: 5, operators.neg: 5,
         operators.invert: 5, operators.inv: 5
     }
@@ -92,7 +92,7 @@ class ExpressionCompiler(SPARQLCompiler):
         operators.lt: '<', operators.gt: '>',
         operators.le: '<=', operators.ge: '>=',
         operators.add: '+', operators.sub: '-',
-        operators.mul: '*', operators.truediv: '/',
+        operators.mul: '*', operators.div: '/', operators.truediv: '/',
         operators.pos: '+', operators.neg: '-',
         operators.invert: '!', operators.inv: '!'
     }

--- a/sparqlquery/sparql/expressions.py
+++ b/sparqlquery/sparql/expressions.py
@@ -86,8 +86,11 @@ class Expression(object):
 
     __mul__ = binary(operator.mul)
     __rmul__ = binary.r(operator.mul)
-    __div__ = binary(operator.truediv)
-    __rdiv__ = binary.r(operator.truediv)
+    __div__ = binary(operator.div)
+    __rdiv__ = binary.r(operator.div)
+
+    __truediv__ = binary(operator.truediv)
+    __rtruediv__ = binary.r(operator.truediv)
 
     # List check.
 

--- a/sparqlquery/sparql/operators.py
+++ b/sparqlquery/sparql/operators.py
@@ -1,5 +1,5 @@
 from operator import or_, and_, pos, neg, inv, invert
-from operator import eq, ne, lt, gt, le, ge, add, sub, mul, truediv
+from operator import eq, ne, lt, gt, le, ge, add, sub, mul, div, truediv
 from sparqlquery.sparql.expressions import Expression, BinaryExpression
 
 __all__ = ['Operator', 'FunctionCall', 'OperatorConstructor',

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -6,7 +6,7 @@ UNARY_OPERATORS = [operator.pos, operator.neg, operator.invert, operator.inv]
 CONDITIONAL_OPERATORS = [operator.and_, operator.or_]
 BINARY_OPERATORS = [operator.eq, operator.ne, operator.lt, operator.gt,
                     operator.le, operator.ge, operator.add, operator.sub,
-                    operator.mul, operator.truediv]
+                    operator.mul, operator.div, operator.truediv]
 BUILTIN_OPERATORS = ['bound', 'isIRI', 'isBlank', 'isLiteral', 'str',
                      'lang', 'datatype', 'logical-or', 'logical-and',
                      'RDFTerm-equal', 'sameTerm', 'langMatches', 'regex']


### PR DESCRIPTION
The idea is it's no good to remove div operator from compiler, because it can be used in Python 2.7 if __future__.division is not imported.
Both operator.div and operator.truediv compile into SPARQL operator '/', so they can live together.