### PR TITLE
Fixed compilation of RDF and RDFS namespace expressions

### DIFF
--- a/sparqlquery/sparql/compiler.py
+++ b/sparqlquery/sparql/compiler.py
@@ -20,7 +20,7 @@ For example, `QueryCompiler.compile()` joins the tokens yielded by calling
 """
 from operator import itemgetter
 from rdflib import Literal, URIRef, Namespace
-from rdflib.term import Variable
+from rdflib.namespace import ClosedNamespace
 from sparqlquery.exceptions import InvalidRequestError
 from sparqlquery.sparql.expressions import ConditionalExpression
 from sparqlquery.sparql.expressions import ListExpression
@@ -30,8 +30,6 @@ from sparqlquery.sparql.operators import FunctionCall
 from sparqlquery.sparql.patterns import GroupGraphPattern, UnionGraphPattern
 from sparqlquery.sparql.patterns import GraphPattern, TriplesSameSubject
 from sparqlquery.sparql.patterns import GraphGraphPattern, Triple, CollectionPattern
-#from sparqlquery.sparql.query import *
-#from sparqlquery.sparql.queryforms import *
 from sparqlquery.sparql.helpers import RDF, XSD, is_a
 from sparqlquery.sparql.util import defrag, to_list
 
@@ -137,6 +135,9 @@ class ExpressionCompiler(SPARQLCompiler):
     def term(self, term, use_prefix=True):
         if isinstance(term, Namespace):
             term = URIRef(term)
+        # RDF and RDFS namespaces are implemented in rdflib as a separate class ClosedNamespace
+        elif isinstance(term, ClosedNamespace):
+            term = term.uri
         if term is None:
             return RDF.nil
         elif not hasattr(term, 'n3'):

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -1,9 +1,10 @@
 import operator
 from nose.tools import assert_raises
-from rdflib import Variable, Namespace, URIRef, Literal, BNode
+from rdflib import Variable, Namespace, URIRef, Literal, BNode, RDF, RDFS, XSD
 from sparqlquery.sparql.expressions import *
 from sparqlquery.sparql.helpers import XSD
 import helpers
+
 
 class TestCreatingExpression:
     def setup(self):
@@ -27,6 +28,22 @@ class TestCreatingExpression:
     def test_default_datatype_is_none(self):
         assert self.one.datatype is None
         assert self.neg_one.datatype is None
+
+
+class TestNamespaceAsExpression(object):
+    def test_namespace_emits_uriref(self):
+        """Check if all namespaces are compiled equally
+        RDF and RDFS are implemented as a separate class ClosedNamespace, but they have to be treated same way as others
+        """
+        ns_to_uri = {
+            XSD: 'http://www.w3.org/2001/XMLSchema#',
+            RDF: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#',
+            RDFS: 'http://www.w3.org/2000/01/rdf-schema#',
+            Namespace('http://example.org/ns#'): 'http://example.org/ns#'
+        }
+        for ns, uri in ns_to_uri.iteritems():
+            assert Expression(ns).compile() == "<%s>" % uri
+
 
 class TestCreatingBinaryExpression:
     def setup(self):


### PR DESCRIPTION
RDF and RDFS namespace expressions were compiling wrong (enclosed in quotes, not <>), because RDF and RDFS in rdflib are implemented as instances of ClosedNamespace (and not Namespace).